### PR TITLE
Ignore failing or missing update-desktop-database

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ ifneq ("$(wildcard ./$(BUILD_DIR))","")
 	mkdir -p $(DESTDIR)$(PIXMAPS_DIR)
 	cp $(NAME).png $(DESTDIR)$(PIXMAPS_DIR)
 	@echo ". ." $(BLUE)", done"$(NONE)
-	update-desktop-database
+	update-desktop-database || true
 else
 	@echo ". ." $(BLUE)", you must build first"$(NONE)
 endif


### PR DESCRIPTION
When packaging mamba update-desktop-database should have no effect at `make install` time; if it is present it fails since /usr/share/applications is not writable.