### PR TITLE
Mamba.desktop, add NSM keys

### DIFF
--- a/src/Mamba.desktop
+++ b/src/Mamba.desktop
@@ -9,3 +9,5 @@ Icon=Mamba
 Categories=AudioVideo;Audio;Midi;
 MimeType=audio/x-midi
 Terminal=false
+X-NSM-Capable=true
+X-NSM-Exec=mamba


### PR DESCRIPTION
This adds NSM related keys to the *.desktop file, so NSM tools can find applications which have NSM support. 

X-NSM-Capable, is used to detect if the application has NSM support. It should ideally become false if the application is build without NSM support.

X-NSM-Exec, is the exec name of the application when used in NSM. It can't contain a path (not /usr/bin/ for example) or command line arguments like %f.

If X-NSM-Exec value is the same as the Exec value, then X-NSM-Exec is not strictly needed, but as the Exec value may change in the future (adding %f or something), I think it's not a bad thing to add it anyway.

As discussed in the nsmd forks issue tracker, issue 40
